### PR TITLE
fixed constructor for Argon2 password initializer

### DIFF
--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/config/AppConfig.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/config/AppConfig.java
@@ -24,7 +24,7 @@ public class AppConfig {
 	}
 	
 	@Bean
-    public PasswordEncoder passwordEncoder() {
-        return new Argon2PasswordEncoder(0, 0, 0, 0, 0);
-    }
+	public PasswordEncoder passwordEncoder() {
+	    return new Argon2PasswordEncoder(16, 32, 1, 16, 32); 
+	}
 }


### PR DESCRIPTION
I fixed the constructor for the Argon2 password constructor so that it allocates the correct number of threads to the system (more than 1).

issue #27 