### PR TITLE
Chris p change foreign key relationship in diet tracker and social post

### DIFF
--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/AccountsModel.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/AccountsModel.java
@@ -3,6 +3,8 @@ package com.riptFitness.Ript_Fitness_Backend.domain.model;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
@@ -40,8 +42,16 @@ public class AccountsModel {
     @JsonIgnoreProperties("account") // Ignore the account field inside exercises when serializing
     private List<ExerciseModel> exercises; // This is a collection (List) that holds exercises
 
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Day> days;
+    
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SocialPost> socialPostList;
+    
+    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SocialPostComment> socialPostComments;
 
-    // Fields:
+	// Fields:
     private String username;
     @JsonIgnore // Ignore password field during serialization
     private String password;
@@ -54,11 +64,6 @@ public class AccountsModel {
     protected void onCreate() {
         this.lastLogin = LocalDateTime.now();
     }
-
-    //Represents a List of social posts that the user makes in the social feed
-    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "account_Id")  // Foreign key column in SocialPost table
-    public List<SocialPost> socialPosts = new ArrayList<>();
 
     // Getters:
     public Long getId() {
@@ -80,6 +85,38 @@ public class AccountsModel {
     public LocalDateTime getlastLogin(){
     	return lastLogin;
     }
+    
+    public List<Workouts> getWorkouts() {
+		return workouts;
+	}
+
+	public void setWorkouts(List<Workouts> workouts) {
+		this.workouts = workouts;
+	}
+
+	public List<Day> getDays() {
+		return days;
+	}
+
+	public void setDays(List<Day> days) {
+		this.days = days;
+	}
+
+	public List<SocialPost> getSocialPostList() {
+		return socialPostList;
+	}
+
+	public void setSocialPostList(List<SocialPost> socialPostList) {
+		this.socialPostList = socialPostList;
+	}
+
+	public List<SocialPostComment> getSocialPostComments() {
+		return socialPostComments;
+	}
+
+	public void setSocialPostComments(List<SocialPostComment> socialPostComments) {
+		this.socialPostComments = socialPostComments;
+	}
 
     // Setters:
     public void setId(Long id) {

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/Day.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/Day.java
@@ -4,13 +4,17 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import jakarta.persistence.Column;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.JoinColumn;
 
@@ -33,8 +37,9 @@ public class Day {
 	
 	public List<Long> foodIdsInFoodsEatenInDayList = new ArrayList<>();
 	
-	@Column(nullable = false)
-	public Long accountId;
+    @ManyToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    public AccountsModel account;
 	
 	public LocalDate date;
 

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/SocialPost.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/SocialPost.java
@@ -10,6 +10,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
 
@@ -20,8 +22,9 @@ public class SocialPost {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	public Long id;
 	
-	@Column(name = "account_id", nullable = false)
-	public Long accountId;
+    @ManyToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    public AccountsModel account;
     
     public String content;
     

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/SocialPostComment.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/SocialPostComment.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.PrePersist;
 
 @Entity
@@ -16,8 +18,9 @@ public class SocialPostComment {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	public Long id;
 	
-    @Column(name = "account_id", nullable = false)  // Specify the column name in the database
-    public Long accountId;
+    @ManyToOne
+    @JoinColumn(name = "account_id", nullable = false)
+    public AccountsModel account;
 	
 	public String content;
 	

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
@@ -15,6 +15,7 @@ public interface NutritionTrackerDayRepository extends JpaRepository<Day, Long>{
 	@Query("SELECT d FROM Day d WHERE d.id = :id AND d.isDeleted = false")
 	Optional<Day> findById(@Param("id")Long id);
 	
-	@Query("SELECT d.id FROM Day d WHERE d.account.id = :accountId AND d.isDeleted = false")
-	Optional<ArrayList<Long>> getDayIdsFromAccountId(@Param("accountId") Long accountId);
+	@Query("SELECT d.id FROM Day d WHERE d.account.id = :accountId AND d.isDeleted = false ORDER BY d.id desc")
+	Optional<ArrayList<Long>> getDayIdsFromAccountId(@Param("accountId") Long accountId, @Param("start") int start, @Param("end") int end);
+	
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
@@ -15,6 +15,6 @@ public interface NutritionTrackerDayRepository extends JpaRepository<Day, Long>{
 	@Query("SELECT d FROM Day d WHERE d.id = :id AND d.isDeleted = false")
 	Optional<Day> findById(@Param("id")Long id);
 	
-	@Query("SELECT d.id FROM Day d WHERE d.accountId = :accountId AND d.isDeleted = false")
-	Optional<ArrayList<Long>> getPostsFromAccountId(@Param("accountId") Long accountId);
+	@Query("SELECT d.id FROM Day d WHERE d.account.id = :accountId AND d.isDeleted = false")
+	Optional<ArrayList<Long>> getDayIdsFromAccountId(@Param("accountId") Long accountId);
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/NutritionTrackerDayRepository.java
@@ -15,7 +15,7 @@ public interface NutritionTrackerDayRepository extends JpaRepository<Day, Long>{
 	@Query("SELECT d FROM Day d WHERE d.id = :id AND d.isDeleted = false")
 	Optional<Day> findById(@Param("id")Long id);
 	
-	@Query("SELECT d.id FROM Day d WHERE d.account.id = :accountId AND d.isDeleted = false ORDER BY d.id desc")
-	Optional<ArrayList<Long>> getDayIdsFromAccountId(@Param("accountId") Long accountId, @Param("start") int start, @Param("end") int end);
+	@Query("SELECT d.id FROM Day d WHERE d.account.id = :accountId AND d.isDeleted = false")
+	Optional<ArrayList<Long>> getDayIdsFromAccountId(@Param("accountId") Long accountId);
 	
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostCommentRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostCommentRepository.java
@@ -15,6 +15,6 @@ public interface SocialPostCommentRepository extends JpaRepository <SocialPostCo
 	@Query("SELECT s FROM SocialPostComment s WHERE s.id = :id AND s.isDeleted = false")
 	Optional<SocialPostComment> findById(@Param("id") Long id);
 
-	@Query("SELECT s.id FROM SocialPostComment s WHERE s.accountId = :accountId AND s.isDeleted = false")
+	@Query("SELECT s.id FROM SocialPostComment s WHERE s.account.id = :accountId AND s.isDeleted = false")
 	Optional<ArrayList<Long>> getPostsFromAccountId(@Param("accountId") Long accountId);
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostCommentRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostCommentRepository.java
@@ -15,6 +15,9 @@ public interface SocialPostCommentRepository extends JpaRepository <SocialPostCo
 	@Query("SELECT s FROM SocialPostComment s WHERE s.id = :id AND s.isDeleted = false")
 	Optional<SocialPostComment> findById(@Param("id") Long id);
 
-	@Query("SELECT s.id FROM SocialPostComment s WHERE s.account.id = :accountId AND s.isDeleted = false")
-	Optional<ArrayList<Long>> getPostsFromAccountId(@Param("accountId") Long accountId);
+	/*
+	Query is currently not used as the endpoint using it has been deprecated
+	@Query("SELECT s FROM SocialPostComment s WHERE s.account.id = :accountId AND s.isDeleted = false")
+	Optional<ArrayList<SocialPostComment>> getPostsFromAccountId(@Param("accountId") Long accountId);
+	*/
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostRepository.java
@@ -16,6 +16,6 @@ public interface SocialPostRepository extends JpaRepository<SocialPost, Long>{
 		@Query("SELECT s FROM SocialPost s WHERE s.id = :id AND s.isDeleted = false")
 		Optional<SocialPost> findById(@Param("id") Long id);
 
-		@Query("SELECT s.id FROM SocialPost s WHERE s.accountId = :accountId AND s.isDeleted = false")
+		@Query("SELECT s.id FROM SocialPost s WHERE s.account.id = :accountId AND s.isDeleted = false")
 		Optional<ArrayList<Long>> getPostsFromAccountId(@Param("accountId") Long accountId);
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostRepository.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/repository/SocialPostRepository.java
@@ -16,6 +16,6 @@ public interface SocialPostRepository extends JpaRepository<SocialPost, Long>{
 		@Query("SELECT s FROM SocialPost s WHERE s.id = :id AND s.isDeleted = false")
 		Optional<SocialPost> findById(@Param("id") Long id);
 
-		@Query("SELECT s.id FROM SocialPost s WHERE s.account.id = :accountId AND s.isDeleted = false")
-		Optional<ArrayList<Long>> getPostsFromAccountId(@Param("accountId") Long accountId);
+		@Query("SELECT s FROM SocialPost s WHERE s.account.id = :accountId AND s.isDeleted = false")
+		Optional<ArrayList<SocialPost>> getPostsFromAccountId(@Param("accountId") Long accountId);
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/SocialPostService.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/SocialPostService.java
@@ -36,7 +36,8 @@ public class SocialPostService {
 	
 	public SocialPostDto addPost(SocialPostDto socialPostDto) {
 		SocialPost socialPostToBeAdded = SocialPostMapper.INSTANCE.toSocialPost(socialPostDto);
-		socialPostToBeAdded.accountId = accountsService.getLoggedInUserId();
+		Long currentlyLoggedInUserId = accountsService.getLoggedInUserId();
+		socialPostToBeAdded.account = accountsRepository.findById(currentlyLoggedInUserId).get();
 		socialPostToBeAdded = socialPostRepository.save(socialPostToBeAdded);
 		return SocialPostMapper.INSTANCE.toSocialPostDto(socialPostToBeAdded);
 	}
@@ -148,8 +149,6 @@ public class SocialPostService {
 	}
 	
 	public SocialPostDto addComment(SocialPostCommentDto socialPostComment) {
-		socialPostComment.accountId = accountsService.getLoggedInUserId();
-		
 		Optional<SocialPost> optionalSocialPostObject = socialPostRepository.findById(socialPostComment.postId);
 		
 		if(optionalSocialPostObject.isEmpty())
@@ -158,6 +157,10 @@ public class SocialPostService {
 		SocialPost socialPostObject = optionalSocialPostObject.get();
 		
 		SocialPostComment socialPostCommentModel = SocialPostCommentMapper.INSTANCE.toSocialPostComment(socialPostComment);
+		
+		Long currentlyLoggedInUserId = accountsService.getLoggedInUserId();
+
+		socialPostCommentModel.account = accountsRepository.findById(currentlyLoggedInUserId).get();
 				
 		socialPostObject.socialPostComments.add(socialPostCommentModel);
 		

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/SocialPostService.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/SocialPostService.java
@@ -53,15 +53,33 @@ public class SocialPostService {
 		return SocialPostMapper.INSTANCE.toSocialPostDto(returnedSocialPostObject);
 	}
 	
-	public ArrayList<Long> getPostsFromAccountId(){
+	public ArrayList<SocialPostDto> getPostsFromAccountId(Integer startIndex, Integer endIndex){
+		if(startIndex > endIndex)
+			throw new RuntimeException("Start index cannot be greater than end index. Start index = " + startIndex + ", end index = " + endIndex);
+		
+		if(startIndex < 0 || endIndex < 0)
+			throw new RuntimeException("Start index and end index must be greater than 0. Start index = " + startIndex + ", end index = " + endIndex);
+				
 		Long currentUsersAccountId = accountsService.getLoggedInUserId();
 		
-		Optional<ArrayList<Long>> postsFromAccountId = socialPostRepository.getPostsFromAccountId(currentUsersAccountId);
+		Optional<ArrayList<SocialPost>> optionalPostsFromAccountId = socialPostRepository.getPostsFromAccountId(currentUsersAccountId);
 		
-		if(postsFromAccountId.isEmpty())
-			return new ArrayList<Long>();
+		if(optionalPostsFromAccountId.isEmpty())
+			return new ArrayList<SocialPostDto>();
 		
-		return postsFromAccountId.get();
+		ArrayList<SocialPost> postsFromAccountId = optionalPostsFromAccountId.get();
+		
+		if(startIndex >= postsFromAccountId.size() || endIndex >= postsFromAccountId.size())
+			throw new RuntimeException("Start index and end index must both be less than or equal to the total number of social posts from the currently logged in user."
+					+ " Start index = " + startIndex + ", end index = " + endIndex + ", total number of posts from logged in user = " + postsFromAccountId.size() + ".");
+		
+		ArrayList<SocialPostDto> postDtosFromAccountId = new ArrayList<SocialPostDto>();
+				
+		for(int i = startIndex; i < endIndex + 1; i++) {
+			postDtosFromAccountId.add(SocialPostMapper.INSTANCE.toSocialPostDto(postsFromAccountId.get(i)));
+		}
+		
+		return postDtosFromAccountId;
 	}
 	
 	public SocialPostDto editPostContent(Long socialPostId, String newSocialPostContent) {
@@ -197,14 +215,25 @@ public class SocialPostService {
 		return SocialPostMapper.INSTANCE.toSocialPostDto(updatedSocialPost);
 	}
 	
-	public ArrayList<Long> getCommentsFromAccountId(){
+	/*
+	*** Getting rid of this endpoint for now as it isn't being used. Will add back if necessary. ***
+	public ArrayList<SocialPostCommentDto> getCommentsFromAccountId(){
 		Long currentUsersAccountId = accountsService.getLoggedInUserId();
 		
-		Optional<ArrayList<Long>> commentsFromAccountId = socialPostCommentRepository.getPostsFromAccountId(currentUsersAccountId);
+		Optional<ArrayList<SocialPostComment>> optionalCommentsFromAccountId = socialPostCommentRepository.getPostsFromAccountId(currentUsersAccountId);
 		
-		if(commentsFromAccountId.isEmpty())
-			return new ArrayList<Long>();
+		if(optionalCommentsFromAccountId.isEmpty())
+			return new ArrayList<SocialPostCommentDto>();
 		
-		return commentsFromAccountId.get();
+		ArrayList<SocialPostComment> commentsFromAccountId = optionalCommentsFromAccountId.get();
+		
+		ArrayList<SocialPostCommentDto> commentDtosFromAccountId = new ArrayList<SocialPostCommentDto>();
+		
+		for(int i = 0; i < commentsFromAccountId.size(); i++) {
+			commentDtosFromAccountId.add(SocialPostCommentMapper.INSTANCE.toSocialPostCommentDto(commentsFromAccountId.get(i)));
+		}
+		
+		return commentDtosFromAccountId;
 	}
+	*/
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/controller/SocialPostController.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/controller/SocialPostController.java
@@ -39,16 +39,10 @@ public class SocialPostController {
 		return new ResponseEntity<>(returnedSocialPostObject, HttpStatus.OK);
 	}
 	
-	@GetMapping("/getPostsFromAccountId")
-	public ResponseEntity<ArrayList<Long>> getPostsFromAccountId(){
-		ArrayList<Long> returnedListOfPostIds = socialPostService.getPostsFromAccountId();
+	@GetMapping("/getPostsFromAccountId/{startIndex}/{endIndex}")
+	public ResponseEntity<ArrayList<SocialPostDto>> getPostsFromAccountId(@PathVariable Integer startIndex, @PathVariable Integer endIndex){
+		ArrayList<SocialPostDto> returnedListOfPostIds = socialPostService.getPostsFromAccountId(startIndex, endIndex);
 		return new ResponseEntity<>(returnedListOfPostIds, HttpStatus.OK);
-	}
-	
-	@GetMapping("/getCommentsFromAccountId")
-	public ResponseEntity<ArrayList<Long>> getCommentsFromAccountId(){
-		ArrayList<Long> returnedListOfCommentIds = socialPostService.getCommentsFromAccountId();
-		return new ResponseEntity<>(returnedListOfCommentIds, HttpStatus.OK);
 	}
 	
 	@PutMapping("/editPostContent/{socialPostId}")
@@ -86,4 +80,13 @@ public class SocialPostController {
 		SocialPostDto socialPostObject = socialPostService.deleteComment(socialPostCommentId);
 		return new ResponseEntity<>(socialPostObject, HttpStatus.OK);
 	}
+	
+	/*
+	*** Getting rid of this endpoint for now, will add back later if necessary ***
+	@GetMapping("/getCommentsFromAccountId")
+	public ResponseEntity<ArrayList<SocialPostCommentDto>> getCommentsFromAccountId(){
+		ArrayList<SocialPostCommentDto> returnedListOfCommentIds = socialPostService.getCommentsFromAccountId();
+		return new ResponseEntity<>(returnedListOfCommentIds, HttpStatus.OK);
+	}
+	*/
 }

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/AccountsDto.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/AccountsDto.java
@@ -17,7 +17,6 @@ public class AccountsDto {
     public String email;
     public LocalDateTime lastLogin; // New date-time field
     public Streak streak;
-    public List<SocialPost> socialPosts;
     
     // Constructor
     public AccountsDto() {

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/DayDto.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/DayDto.java
@@ -3,6 +3,7 @@ package com.riptFitness.Ript_Fitness_Backend.web.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.riptFitness.Ript_Fitness_Backend.domain.model.AccountsModel;
 import com.riptFitness.Ript_Fitness_Backend.domain.model.Food;
 
 //Dto must match the model class exactly minus the "@" declarations
@@ -11,7 +12,6 @@ public class DayDto {
 	public Long id;
 	public List<Food> foodsEatenInDay = new ArrayList<>();	
 	public List<Long> foodIdsInFoodsEatenInDayList = new ArrayList<>();
-	public Long accountId;
 	public double calories;
 	public double totalCarbs;
 	public double totalProtein;

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/SocialPostCommentDto.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/SocialPostCommentDto.java
@@ -5,9 +5,7 @@ import java.time.LocalDateTime;
 public class SocialPostCommentDto {
 
 	public Long id;
-	
-	public Long accountId;
-	
+		
 	public String content;
 	
     public Long postId;

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/SocialPostDto.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/SocialPostDto.java
@@ -6,9 +6,7 @@ import java.util.List;
 public class SocialPostDto {
 
 	public Long id;
-	
-	public Long accountId;
-    
+	    
     public String content;
     
     public int numberOfLikes;

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/NutritionTrackerServiceTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/NutritionTrackerServiceTest.java
@@ -18,8 +18,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import com.riptFitness.Ript_Fitness_Backend.domain.model.AccountsModel;
 import com.riptFitness.Ript_Fitness_Backend.domain.model.Day;
 import com.riptFitness.Ript_Fitness_Backend.domain.model.Food;
+import com.riptFitness.Ript_Fitness_Backend.domain.repository.AccountsRepository;
 import com.riptFitness.Ript_Fitness_Backend.domain.repository.NutritionTrackerDayRepository;
 import com.riptFitness.Ript_Fitness_Backend.domain.repository.NutritionTrackerFoodRepository;
 import com.riptFitness.Ript_Fitness_Backend.infrastructure.service.AccountsService;
@@ -38,6 +40,9 @@ public class NutritionTrackerServiceTest {
 	@Mock
 	private AccountsService accountsService;
 	
+	@Mock
+	private AccountsRepository accountsRepository;
+	
 	@InjectMocks
 	private NutritionTrackerService nutritionTrackerServiceForServiceTests;
 	
@@ -47,6 +52,7 @@ public class NutritionTrackerServiceTest {
 	private Food foodTwo;
 	private DayDto dayDto;
 	private Day day;
+	private AccountsModel account;
 	
 	@BeforeEach
 	public void setUp() {
@@ -89,6 +95,9 @@ public class NutritionTrackerServiceTest {
 
 		day = new Day();
 		day.foodsEatenInDay = List.of(food, foodTwo);
+		
+		account = new AccountsModel();
+		day.account = account;
 	}
 	
 	@Test
@@ -177,6 +186,7 @@ public class NutritionTrackerServiceTest {
 	@Test
 	void testServiceAddDayValid() {
 		when(nutritionTrackerDayRepository.save(any(Day.class))).thenReturn(day);
+		when(accountsRepository.findById(any(Long.class))).thenReturn(Optional.of(account));
 		
 		DayDto result = nutritionTrackerServiceForServiceTests.addDay(dayDto);
 		
@@ -203,7 +213,7 @@ public class NutritionTrackerServiceTest {
 	@Test
 	void testServiceGetDayIdsOfLoggedInUserValid() {
 		when(accountsService.getLoggedInUserId()).thenReturn(1L);
-		when(nutritionTrackerDayRepository.getPostsFromAccountId(anyLong())).thenReturn(Optional.of(new ArrayList<>()));
+		when(nutritionTrackerDayRepository.getDayIdsFromAccountId(anyLong())).thenReturn(Optional.of(new ArrayList<>()));
 		
 		ArrayList<Long> result = nutritionTrackerServiceForServiceTests.getDayIdsOfLoggedInUser();
 		
@@ -213,7 +223,7 @@ public class NutritionTrackerServiceTest {
 	@Test
 	void testServiceGetDayIdsOfLoggedInUserInvalidNoDaysForUser() {
 		when(accountsService.getLoggedInUserId()).thenReturn(1L);
-		when(nutritionTrackerDayRepository.getPostsFromAccountId(anyLong())).thenReturn(Optional.empty());
+		when(nutritionTrackerDayRepository.getDayIdsFromAccountId(anyLong())).thenReturn(Optional.empty());
 		
 		ArrayList<Long> result = nutritionTrackerServiceForServiceTests.getDayIdsOfLoggedInUser();
 		

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/SocialPostServiceTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/SocialPostServiceTest.java
@@ -58,7 +58,6 @@ public class SocialPostServiceTest {
 		MockitoAnnotations.openMocks(this);
 		
 		socialPost = new SocialPostDto();
-		socialPost.accountId = 1L;
 		socialPost.content = "Just benched 500 pounds, my name is Chris and I'm so strong!!";
 		socialPost.numberOfLikes = 2;
 		socialPost.userIDsOfLikes = new ArrayList<>();
@@ -71,21 +70,22 @@ public class SocialPostServiceTest {
 		socialPost.socialPostComments.add(commentOne);
 		socialPost.socialPostComments.add(commentTwo);
 		
-		commentOne.accountId = 2L;
 		commentOne.content = "Great job Chris, OMG!";
 		commentOne.postId = 1L;
 		
-		commentTwo.accountId = 3L;
 		commentTwo.content = "Wow! So strong!!!";
 		commentTwo.postId = 1L;
 		
-		commentThree.accountId = 4L;
 		commentThree.content = "You can do better.";
 		commentThree.postId = 1L;
 		
 		socialPostModel = SocialPostMapper.INSTANCE.toSocialPost(socialPost);
+		socialPostModel.account = new AccountsModel();
+		socialPostModel.account.setId(1L);
 		
 		commentOneModel = SocialPostCommentMapper.INSTANCE.toSocialPostComment(commentOne);
+		commentOneModel.account = new AccountsModel();
+		commentOneModel.account.setId(3L);
 		
 		account = new AccountsModel();
 		
@@ -95,6 +95,7 @@ public class SocialPostServiceTest {
 	@Test
 	void testServiceAddPostValid() {
 		when(socialPostRepository.save(any(SocialPost.class))).thenReturn(socialPostModel);
+		when(accountsRepository.findById(any(Long.class))).thenReturn(Optional.of(account));
 		when(accountsService.getLoggedInUserId()).thenReturn(1L);
 		
 		SocialPostDto result = socialPostService.addPost(socialPost);
@@ -111,7 +112,6 @@ public class SocialPostServiceTest {
 		SocialPostDto result = socialPostService.getPost(1L);
 		
 		assertNotNull(result);
-		assertEquals(1L, result.accountId);
 		assertEquals(2, result.socialPostComments.size());
 	}
 	
@@ -150,7 +150,6 @@ public class SocialPostServiceTest {
 		SocialPostDto result = socialPostService.deletePost(1L);
 		
 		assertNotNull(result);
-		assertEquals(2L, result.socialPostComments.get(0).accountId);
 		assertEquals("Wow! So strong!!!", result.socialPostComments.get(1).content);
 	}
 	
@@ -219,7 +218,8 @@ public class SocialPostServiceTest {
 	
 	@Test
 	void testServiceAddCommentValid() {
-		when(socialPostRepository.findById(1L)).thenReturn(Optional.of(socialPostModel));
+		when(socialPostRepository.findById(any(Long.class))).thenReturn(Optional.of(socialPostModel));
+		when(accountsRepository.findById(any(Long.class))).thenReturn(Optional.of(account));
 		when(socialPostRepository.save(any(SocialPost.class))).thenReturn(socialPostModel);
 		
 		SocialPostDto result = socialPostService.addComment(commentThree);

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/SocialPostControllerTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/SocialPostControllerTest.java
@@ -61,7 +61,6 @@ public class SocialPostControllerTest {
 	@BeforeEach
 	public void setUp() {
 		socialPost = new SocialPostDto();
-		socialPost.accountId = 1L;
 		socialPost.content = "Just benched 500 pounds, my name is Chris and I'm so strong!!";
 		socialPost.numberOfLikes = 2;
 		socialPost.userIDsOfLikes = new ArrayList<>();
@@ -74,15 +73,12 @@ public class SocialPostControllerTest {
 		socialPost.socialPostComments.add(commentOne);
 		socialPost.socialPostComments.add(commentTwo);
 		
-		commentOne.accountId = 2L;
 		commentOne.content = "Great job Chris, OMG!";
 		commentOne.postId = 1L;
 		
-		commentTwo.accountId = 3L;
 		commentTwo.content = "Wow! So strong!!!";
 		commentTwo.postId = 1L;
 		
-		commentThree.accountId = 4L;
 		commentThree.content = "You can do better.";
 		commentThree.postId = 1L;
 	}
@@ -102,11 +98,9 @@ public class SocialPostControllerTest {
 				.content(objectMapper.writeValueAsBytes(socialPost)))
 				.andExpect(status().isCreated())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.accountId").value(1))
 				.andExpect(jsonPath("$.content").value("Just benched 500 pounds, my name is Chris and I'm so strong!!"))
 				.andExpect(jsonPath("$.numberOfLikes").value(2))
 				.andExpect(jsonPath("$.socialPostComments[0].content").value("Great job Chris, OMG!"))
-				.andExpect(jsonPath("$.socialPostComments[1].accountId").value("3"))
 				.andReturn();
 	}
 	
@@ -128,11 +122,9 @@ public class SocialPostControllerTest {
 				.content(""))
 				.andExpectAll(status().isOk())
 				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
-				.andExpect(jsonPath("$.accountId").value(1))
 				.andExpect(jsonPath("$.content").value("Just benched 500 pounds, my name is Chris and I'm so strong!!"))
 				.andExpect(jsonPath("$.numberOfLikes").value(2))
 				.andExpect(jsonPath("$.socialPostComments[0].content").value("Great job Chris, OMG!"))
-				.andExpect(jsonPath("$.socialPostComments[1].accountId").value("3"))
 				.andReturn();
 	}
 	


### PR DESCRIPTION
-Changed relationship between diet tracker feature, as well as the social post feature, and Account so that a foreign key relationship is defined and visible to database schema generation.

-Changed getAllPostsFromAccountId endpoint to return an ArrayList of SocialPostDto objects instead of just their Long Ids to allow the front end to make less API calls

-Added start and end indexes to the getAllPostsFromAccountId endpoint to limit how long the returned ArrayList is to the front end to avoid sending very large ArrayLists in the case that a user is very active

-Deleted the getAllCommentFromAccountId endpoint, its service method, and its repository interface query, as it is not needed. The code from all three has been commented out instead of deleted in the case that we want to add it back at a later date.