### PR TITLE
Bugfixes to the Friend Request Feature

### DIFF
--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/FriendRequest.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/FriendRequest.java
@@ -42,6 +42,8 @@ public class FriendRequest {
 	public String toUsername;	//Username of toAccount's userProfile
 	
 	public LocalDateTime dateTimeOfMostRecentChangeToStatus;
+	
+	public FriendRequest() {}	//Required for database interactions to work
 
 	public FriendRequest(AccountsModel fromAccount, AccountsModel toAccount, Long accountIdOfFromAccount, Long accountIdOfToAccount, RequestStatus status, String fromUsername,
 			String toUsername, LocalDateTime dateTimeOfMostRecentChangeToStatus) {

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/FriendRequestService.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/FriendRequestService.java
@@ -60,7 +60,7 @@ public class FriendRequestService {
 		
 		//FriendRequest constructor order: fromAccount, toAccount, accountIdOfFromAccount, accountIdOfToAccount, RequestStatus, fromUsername, toUsername, LocalDateTime
 		FriendRequest fromRequest = new FriendRequest(currentlyLoggedInUser, toAccountUser, currentlyLoggedInUser.getId(), toAccountUser.getId(), RequestStatus.SENT, fromUsername, toUsername, LocalDateTime.now());
-		FriendRequest toRequest = new FriendRequest(toAccountUser, currentlyLoggedInUser, toAccountUser.getId(), currentlyLoggedInUser.getId(), RequestStatus.PENDING, fromUsername, toUsername, LocalDateTime.now());
+		FriendRequest toRequest = new FriendRequest(toAccountUser, currentlyLoggedInUser, toAccountUser.getId(), currentlyLoggedInUser.getId(), RequestStatus.PENDING, toUsername, fromUsername, LocalDateTime.now());
 		
 		friendRequestRepository.save(fromRequest);
 		friendRequestRepository.save(toRequest);

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/controller/FriendRequestController.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/controller/FriendRequestController.java
@@ -38,7 +38,7 @@ public class FriendRequestController {
 		return new ResponseEntity<>(returnedStatusString, HttpStatus.OK);
 	}
 	
-	@GetMapping("/getAllAccountsWithSpecifcStatus/{status}")
+	@GetMapping("/getAllAccountsWithSpecificStatus/{status}")
 	public ResponseEntity<ArrayList<String>> getAllAccountsWithSpecificStatus(@PathVariable RequestStatus status){
 		ArrayList<String> returnedListOfUsernames = friendRequestService.getAllAccountsWithSpecificStatus(status);
 		return new ResponseEntity<>(returnedListOfUsernames, HttpStatus.OK);

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/FriendRequestControllerTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/FriendRequestControllerTest.java
@@ -115,7 +115,7 @@ public class FriendRequestControllerTest {
 	public void testGetAllAccountsWithSpecificStatusValidRequest() throws Exception {
 		when(friendRequestService.getAllAccountsWithSpecificStatus(any(RequestStatus.class))).thenReturn(new ArrayList<String>(List.of("cpichle1", "nHalash")));
 		
-		mockMvc.perform(get("/friendRequest/getAllAccountsWithSpecifcStatus/PENDING")
+		mockMvc.perform(get("/friendRequest/getAllAccountsWithSpecificStatus/PENDING")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(""))
 				.andExpect(status().isOk())
@@ -125,7 +125,7 @@ public class FriendRequestControllerTest {
 	
 	@Test
 	public void testGetAllAccountsWithSpecificStatusInvalidRequestNoPathVariable() throws Exception {
-		mockMvc.perform(get("/friendRequest/getAllAccountsWithSpecifcStatus"))
+		mockMvc.perform(get("/friendRequest/getAllAccountsWithSpecificStatus"))
 				.andExpect(status().isInternalServerError())
 				.andReturn();
 	}


### PR DESCRIPTION
1) Spelled "specific" correctly in getAllAccountsWithSpecificStatus endpoint
2) Added default constructor to FriendRequest.java which is required to do database interactions
3) Switched around fromUsername and toUsername Strings to match what's expected in FriendRequest constructor in FriendRequestService.java