### PR TITLE
Changed sendRequest Service method to get rid of non-null error

### DIFF
--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/FriendRequestService.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/FriendRequestService.java
@@ -136,7 +136,7 @@ public class FriendRequestService {
 		FriendRequest fromRequest = friendRequestRepository.findByAccountIdOfFromAccountAndAccountIdOfToAccount(currentlyLoggedInUserId, toAccountId).get();
 		FriendRequest toRequest = friendRequestRepository.findByAccountIdOfFromAccountAndAccountIdOfToAccount(toAccountId, currentlyLoggedInUserId).get();
 		
-		fromRequest = FriendRequestMapper.INSTANCE.toFriendRequest(friendRequestDto);
+		fromRequest.status = friendRequestDto.status;
 		changeToRequestBasedOnStatus(toRequest, friendRequestDto.status);
 		
 		fromRequest.dateTimeOfMostRecentChangeToStatus = LocalDateTime.now();


### PR DESCRIPTION
Instead of changing the row in the database to the request body DTO, just take the status in the request body DTO and change only the status column of the row being affected as the fromRequest in the sendRequest endpoint