### PR TITLE
Fixed Bug That Included Infinite JSON return to Front End

### DIFF
--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/AccountsModel.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/AccountsModel.java
@@ -37,6 +37,7 @@ public class AccountsModel {
     private Streak streak;
     
     @OneToOne(mappedBy = "account", cascade = CascadeType.ALL, fetch = FetchType.LAZY, optional = false)
+    @JsonManagedReference
     private UserProfile userProfile;
     
     // If you want to define a bi-directional relationship

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/Day.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/Day.java
@@ -34,9 +34,7 @@ public class Day {
 			inverseJoinColumns = @JoinColumn(name = "food_id")
 	)
 	public List<Food> foodsEatenInDay = new ArrayList<>();
-	
-	public List<Long> foodIdsInFoodsEatenInDayList = new ArrayList<>();
-	
+		
     @ManyToOne
     @JoinColumn(name = "account_id", nullable = false)
     public AccountsModel account;

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/UserProfile.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/domain/model/UserProfile.java
@@ -1,6 +1,9 @@
 package com.riptFitness.Ript_Fitness_Backend.domain.model;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -38,6 +41,7 @@ public class UserProfile {
     
     @OneToOne
     @JoinColumn(name = "account_id", referencedColumnName = "id")
+    @JsonBackReference
     private AccountsModel account;
 
     // Soft delete flag

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/NutritionTrackerService.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/service/NutritionTrackerService.java
@@ -211,7 +211,6 @@ public class NutritionTrackerService {
 		
 		for(Food foodInList : foodsAddedToDayObject) {
 			dayBeingUpdated.foodsEatenInDay.add(foodInList);
-			dayBeingUpdated.foodIdsInFoodsEatenInDayList.add(foodInList.id);
 		}
 		
 		calculateTotalDayStats(dayBeingUpdated);	
@@ -242,7 +241,6 @@ public class NutritionTrackerService {
 		
 		for(Food foodInList : foodsAddedToDayObject) {
 			dayBeingUpdated.foodsEatenInDay.remove(foodInList);
-			dayBeingUpdated.foodIdsInFoodsEatenInDayList.remove(foodInList.id);
 		}
 		
 		calculateTotalDayStats(dayBeingUpdated);	

--- a/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/DayDto.java
+++ b/backend/Ript-Fitness-Backend/src/main/java/com/riptFitness/Ript_Fitness_Backend/web/dto/DayDto.java
@@ -10,8 +10,7 @@ import com.riptFitness.Ript_Fitness_Backend.domain.model.Food;
 public class DayDto {
 
 	public Long id;
-	public List<Food> foodsEatenInDay = new ArrayList<>();	
-	public List<Long> foodIdsInFoodsEatenInDayList = new ArrayList<>();
+	public List<FoodDto> foodsEatenInDay = new ArrayList<>();	
 	public double calories;
 	public double totalCarbs;
 	public double totalProtein;

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/NutritionTrackerServiceTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/infrastructure/serviceTests/NutritionTrackerServiceTest.java
@@ -94,7 +94,7 @@ public class NutritionTrackerServiceTest {
 		foodTwo.multiplier = 0.5;
 				
 		dayDto = new DayDto();
-		dayDto.foodsEatenInDay = List.of(food, foodTwo);
+		dayDto.foodsEatenInDay = List.of(foodDto, foodDtoTwo);
 
 		day = new Day();
 		day.foodsEatenInDay = List.of(food, foodTwo);

--- a/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/NutritionTrackerControllerTest.java
+++ b/backend/Ript-Fitness-Backend/src/test/java/com/riptFitness/Ript_Fitness_Backend/web/controllerTests/NutritionTrackerControllerTest.java
@@ -100,7 +100,7 @@ public class NutritionTrackerControllerTest {
 		foodTwo.multiplier = 0.5;
 				
 		dayDto = new DayDto();
-		dayDto.foodsEatenInDay = List.of(food, foodTwo);
+		dayDto.foodsEatenInDay = List.of(foodDto, foodDtoTwo);
 		dayDto.totalWaterConsumed = 0;
 
 		day = new Day();


### PR DESCRIPTION
-Changed List of Food objects in DayDto to a List of FoodDto objects, as the Food object return was causing infinite serialization between AccountsModel and UserProfile
-Got rid of List of FoodIDs in Day and DayDto objects as it isn't needed
-Added @JsonBackReference and @JsonManagedReference to UserProfile and AccountsModel objects to avoid infinite serialization in the future